### PR TITLE
Replaced German link with browser-language link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ Wikimedia Foundation doesn't care anymore, but we do.
 
 Code is currently under Apache License 2.0; see the file COPYING for details.
 
-[App is now available on the AppStore](https://itunes.apple.com/de/app/commons-reloaded/id962894692?mt=8)
+[App is now available on the AppStore](https://itunes.apple.com/app/commons-reloaded/id962894692)


### PR DESCRIPTION
With the previous link, all users were directed to the German-language page. Now, they should be directed to the page that matches their browser's language.
